### PR TITLE
Allow ActiveRecordViews to load ERB files

### DIFF
--- a/lib/active_record_views.rb
+++ b/lib/active_record_views.rb
@@ -21,6 +21,8 @@ module ActiveRecordViews
     self.sql_load_path.each do |dir|
       path = "#{dir}/#{name}.sql"
       return path if File.exists?(path)
+      path = path + '.erb'
+      return path if File.exists?(path)
     end
     raise "could not find #{name}.sql"
   end

--- a/lib/active_record_views/extension.rb
+++ b/lib/active_record_views/extension.rb
@@ -1,3 +1,5 @@
+require 'erb'
+
 module ActiveRecordViews
   module Extension
     extend ActiveSupport::Concern
@@ -13,8 +15,14 @@ module ActiveRecordViews
         sql ||= begin
           sql_path = ActiveRecordViews.find_sql_file(self.name.underscore)
           ActiveRecordViews.register_for_reload self, sql_path
-          File.read sql_path
+
+          if sql_path.end_with?('.erb')
+            ERB.new(File.read(sql_path)).result
+          else
+            File.read(sql_path)
+          end
         end
+
         unless ActiveRecordViews::Extension.currently_migrating?
           ActiveRecordViews.create_view self.connection, self.table_name, sql
         end

--- a/spec/active_record_views_extension_spec.rb
+++ b/spec/active_record_views_extension_spec.rb
@@ -17,6 +17,11 @@ describe ActiveRecordViews::Extension do
       expect(Namespace::TestModel.first.name).to eq 'Namespaced SQL file'
     end
 
+    it 'creates database views from external ERB files' do
+      expect(ActiveRecordViews).to receive(:create_view).once.and_call_original
+      expect(ErbTestModel.first.name).to eq 'ERB file'
+    end
+
     it 'errors if external SQL file is missing' do
       expect {
         MissingFileTestModel

--- a/spec/internal/app/models/erb_test_model.rb
+++ b/spec/internal/app/models/erb_test_model.rb
@@ -1,0 +1,3 @@
+class ErbTestModel < ActiveRecord::Base
+  is_view
+end

--- a/spec/internal/app/models/erb_test_model.sql.erb
+++ b/spec/internal/app/models/erb_test_model.sql.erb
@@ -1,0 +1,1 @@
+SELECT 1 AS id, '<%= "ERB" %> file'::text AS name;


### PR DESCRIPTION
Partially fixes: #6 

First it checks for a matching `.sql` file before looking for a `.erb`

Could potentially use some work to make partial rendering a thing without having to go:

``` erb
<%= File.read '/path/to/_partial.erb' %>
```
