### PR TITLE
Schema dump cleanup

### DIFF
--- a/lib/tasks/active_record_views.rake
+++ b/lib/tasks/active_record_views.rake
@@ -63,9 +63,9 @@ Rake::Task[schema_rake_task].enhance do
       end
 
       File.open filename, 'a' do |io|
-        File.foreach(active_record_views_dump.path) do |line|
-          io.puts line
-        end
+        # Seek to the end to ensure we don't overwrite the existing content
+        io.seek(0, IO::SEEK_END)
+        IO.copy_stream active_record_views_dump, io
 
         io.puts 'UPDATE public.active_record_views SET refreshed_at = NULL WHERE refreshed_at IS NOT NULL;'
       end

--- a/lib/tasks/active_record_views.rake
+++ b/lib/tasks/active_record_views.rake
@@ -70,6 +70,7 @@ Rake::Task[schema_rake_task].enhance do
         io.puts 'UPDATE public.active_record_views SET refreshed_at = NULL WHERE refreshed_at IS NOT NULL;'
       end
     ensure
+      active_record_views_dump.close
       active_record_views_dump.unlink
     end
   end

--- a/lib/tasks/active_record_views.rake
+++ b/lib/tasks/active_record_views.rake
@@ -68,7 +68,7 @@ Rake::Task[schema_rake_task].enhance do
         io.puts 'UPDATE public.active_record_views SET refreshed_at = NULL WHERE refreshed_at IS NOT NULL;'
       end
     ensure
-      active_record_views_dump.close
+      active_record_views_dump.unlink
     end
   end
 end

--- a/lib/tasks/active_record_views.rake
+++ b/lib/tasks/active_record_views.rake
@@ -58,7 +58,9 @@ Rake::Task[schema_rake_task].enhance do
       system("pg_dump --data-only --no-owner --table=active_record_views #{Shellwords.escape database} >> #{Shellwords.escape active_record_views_dump.path}")
       raise 'active_record_views metadata dump failed' unless $?.success?
 
-      ActiveRecordViews::RakeTaskUtilities.remove_sql_header_comments(active_record_views_dump.path)
+      if Gem::Version.new(Rails.version) >= Gem::Version.new("5.1")
+        pg_tasks.send(:remove_sql_header_comments, active_record_views_dump.path)
+      end
 
       File.open filename, 'a' do |io|
         File.foreach(active_record_views_dump.path) do |line|
@@ -69,29 +71,6 @@ Rake::Task[schema_rake_task].enhance do
       end
     ensure
       active_record_views_dump.unlink
-    end
-  end
-end
-
-module ActiveRecordViews
-  module RakeTaskUtilities
-    SQL_COMMENT_BEGIN = "--".freeze
-
-    # https://github.com/rails/rails/blob/93e7343db41156c6c90261754129fc0446515a09/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb#L121-L134
-    def self.remove_sql_header_comments(filename)
-      removing_comments = true
-      tempfile = Tempfile.open("uncommented_structure.sql")
-      begin
-        File.foreach(filename) do |line|
-          unless removing_comments && (line.start_with?(SQL_COMMENT_BEGIN) || line.blank?)
-            tempfile << line
-            removing_comments = false
-          end
-        end
-      ensure
-        tempfile.close
-      end
-      FileUtils.cp(tempfile.path, filename)
     end
   end
 end

--- a/lib/tasks/active_record_views.rake
+++ b/lib/tasks/active_record_views.rake
@@ -53,7 +53,7 @@ Rake::Task[schema_rake_task].enhance do
     pg_tasks.send(:set_psql_env)
 
     require 'shellwords'
-    system("pg_dump --data-only --table=active_record_views #{Shellwords.escape database} >> #{Shellwords.escape filename}")
+    system("pg_dump --data-only --no-owner --table=active_record_views #{Shellwords.escape database} >> #{Shellwords.escape filename}")
     raise 'active_record_views metadata dump failed' unless $?.success?
 
     File.open filename, 'a' do |io|

--- a/lib/tasks/active_record_views.rake
+++ b/lib/tasks/active_record_views.rake
@@ -52,14 +52,14 @@ Rake::Task[schema_rake_task].enhance do
     pg_tasks = tasks.send(:class_for_adapter, adapter).new(config)
     pg_tasks.send(:set_psql_env)
 
-    require 'shellwords'
-    active_record_views_dump = Tempfile.open("active_record_views_dump.sql")
-    system("pg_dump --data-only --no-owner --table=active_record_views #{Shellwords.escape database} >> #{Shellwords.escape active_record_views_dump.path}")
-    raise 'active_record_views metadata dump failed' unless $?.success?
-
-    ActiveRecordViews::RakeTaskUtilities.remove_sql_header_comments(active_record_views_dump.path)
-
     begin
+      active_record_views_dump = Tempfile.open("active_record_views_dump.sql")
+      require 'shellwords'
+      system("pg_dump --data-only --no-owner --table=active_record_views #{Shellwords.escape database} >> #{Shellwords.escape active_record_views_dump.path}")
+      raise 'active_record_views metadata dump failed' unless $?.success?
+
+      ActiveRecordViews::RakeTaskUtilities.remove_sql_header_comments(active_record_views_dump.path)
+
       File.open filename, 'a' do |io|
         File.foreach(active_record_views_dump.path) do |line|
           io.puts line

--- a/spec/tasks_spec.rb
+++ b/spec/tasks_spec.rb
@@ -77,6 +77,8 @@ describe 'rake tasks' do
 
       expect(File.exist?('spec/internal/db/schema.rb')).to eq false
       sql = File.read('spec/internal/db/structure.sql')
+      expect(sql).to match(/CREATE TABLE public\.schema_migrations/)
+      expect(sql).to match(/CREATE VIEW public\.test_view/)
       expect(sql).to match(/COPY public\.active_record_views.+test_view\tTestView/m)
       expect(sql).to match(/UPDATE public\.active_record_views SET refreshed_at = NULL/)
     end


### PR DESCRIPTION
My local `git diff` after the changes:

```diff
diff --git a/db/structure.sql b/db/structure.sql
index fce3a91ea2..6860966b58 100644
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6250,13 +6250,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210518053839');


---
--- PostgreSQL database dump
---
-
--- Dumped from database version 10.16
--- Dumped by pg_dump version 10.16
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -6269,7 +6262,7 @@ SET client_min_messages = warning;
 SET row_security = off;

 --
--- Data for Name: active_record_views; Type: TABLE DATA; Schema: public; Owner: odin
+-- Data for Name: active_record_views; Type: TABLE DATA; Schema: public; Owner: -
 --

 COPY public.active_record_views (name, class_name, checksum, options, refreshed_at) FROM stdin;
 ```