### PR TITLE
allow this gem to be used in rails v7.1.x apps

### DIFF
--- a/activerecord_views.gemspec
+++ b/activerecord_views.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'activerecord', ['>= 5.2', '< 7.1']
+  gem.add_dependency 'activerecord', ['>= 5.2', '< 7.2']
 
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'rspec-rails', '>= 2.14'


### PR DESCRIPTION
relax the rails max version constraint to allow v7.1.x